### PR TITLE
Override cached systems with uniqueSystemIps

### DIFF
--- a/wledeffects.js
+++ b/wledeffects.js
@@ -138,6 +138,7 @@ $(function(){
                         }
                     }else{
                         wledEffectsConfig = JSON.parse(json);
+                        wledEffectsConfig.systems = uniqueSystemIps;
                     }
                     uniqueModels = [];
                     


### PR DESCRIPTION
I had invalid ip addresses cached that was breaking the model lookup. I was getting either a timeout for a dead host, or a 404 from a pi that used to run fpp but is not running octopi. The plugin tries to hit every ip in the systems array for a list of models and if it fails on any of them the models list doesnt get populated.
This one liner got it fixed for me, but Im sure a better approch, in addition to this, would be to catch the error so things still work if one of the hosts is inaccessible. 