### PR TITLE
9.4update

### DIFF
--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,24 +1,35 @@
 {
-	"repoName": "fpp-WledEffects",
-	"name": "WLED Effects",
-	"author": "Adam Coulombe",
-	"description": "This plugin adds a UI page with buttons to start and stop the built-in WLED effects",
-	"homeURL": "https://github.com/adamcoulombe/fpp-WledEffects",
-	"srcURL": "https://github.com/adamcoulombe/fpp-WledEffects.git",
-	"bugURL": "https://github.com/adamcoulombe/fpp-WledEffects/issues",
-	"versions": [
-		{
-			"minFPPVersion": "5.0",
-			"maxFPPVersion": "6.999",
-			"branch": "main",
-			"sha": "0763c8537d8dceebebf0890eb2513ad62b965dc6"
-		},
-                {
-                        "minFPPVersion": "7.0",
-                        "maxFPPVersion": "0",
-                        "branch": "main",
-                        "sha": ""
-                }
-	]
+  "repoName": "fpp-WledEffects",
+  "name": "WLED Effects",
+  "author": "Adam Coulombe (community updates for FPP 8.x/9.x)",
+  "description": "Adds a UI page with buttons to start/stop built-in WLED effects on Pixel Overlay Models. Updated for FPP 8.x and 9.x compatibility (new API endpoints, multisync fixes, no duplicates, auto-scroll). Tested on 9.4.",
+  "homeURL": "https://github.com/adamcoulombe/fpp-WledEffects",
+  "srcURL": "https://github.com/adamcoulombe/fpp-WledEffects.git",
+  "bugURL": "https://github.com/adamcoulombe/fpp-WledEffects/issues",
+  "versions": [
+    {
+      "minFPPVersion": "5.0",
+      "maxFPPVersion": "6.999",
+      "branch": "main",
+      "sha": "0763c8537d8dceebebf0890eb2513ad62b965dc6"
+    },
+    {
+      "minFPPVersion": "7.0",
+      "maxFPPVersion": "7.999",
+      "branch": "main",
+      "sha": ""
+    },
+    {
+      "minFPPVersion": "8.0",
+      "maxFPPVersion": "8.999",
+      "branch": "main",
+      "sha": ""
+    },
+    {
+      "minFPPVersion": "9.0",
+      "maxFPPVersion": "9.999",
+      "branch": "main",
+      "sha": ""
+    }
+  ]
 }
-

--- a/wledeffects.js
+++ b/wledeffects.js
@@ -1,6 +1,6 @@
-var uniqueSystemIps={};
-var uniqueModels=[];
-var wledEffectsConfig = {}
+var uniqueSystemIps = {};
+var uniqueModels = [];
+var wledEffectsConfig = {};
 
 function SaveWledEffectsConfig() {
     var data = JSON.stringify(wledEffectsConfig);
@@ -11,305 +11,220 @@ function SaveWledEffectsConfig() {
         data: data,
         processData: false,
         contentType: 'application/json',
-        success: function (data) {
-
-        }
+        success: function () {}
     });
 }
 
-function getUniqueSystemIps(uniqueSystems){
-    var ips=[];
-    Object.keys(uniqueSystems).forEach(function(key, index) {
+function getUniqueSystemIps(uniqueSystems) {
+    var ips = [];
+    Object.keys(uniqueSystems).forEach(function(key) {
         ips.push(uniqueSystems[key].address);
     });
     return ips;
 }
-function getSelectedModels(){
-    var selectedModels=[]
-    $('.fpp-WledEffects-Model-Selections input[type=checkbox]:is(:checked)').each(function(){
+
+function getSelectedModels() {
+    var selectedModels = [];
+    $('.fpp-WledEffects-Model-Selections input[type=checkbox]:checked').each(function() {
         selectedModels.push($(this).data('model-name'));
-    })
+    });
     return selectedModels;
 }
 
-function getSelectedSystems(){
-    var selectedSystems=[]
-    $('#fpp-WledEffects-systems input[type=checkbox]:is(:checked)').each(function(){
+function getSelectedSystems() {
+    var selectedSystems = [];
+    $('#fpp-WledEffects-systems input[type=checkbox]:checked').each(function() {
         selectedSystems.push($(this).data('address'));
-    })
+    });
     return selectedSystems;
 }
-function getUniqueModels(){
+
+function getUniqueModels() {
     var uniqueSystemModelRequests = [];
     uniqueModels = [];
-    if(wledEffectsConfig.multisync==true){
-        $.each(wledEffectsConfig.systems,(i,v)=>{
+    if (wledEffectsConfig.multisync === true) {
+        $.each(wledEffectsConfig.systems || [], (i, v) => {
             uniqueSystemModelRequests.push(
                 $.ajax({
                     type: "GET",
-                    url: 'plugin.php?plugin=fpp-WledEffects&page=remotemodels.php&nopage=1&ip='+v,
+                    url: 'plugin.php?plugin=fpp-WledEffects&page=remotemodels.php&nopage=1&ip=' + v,
                     dataType: 'json',
                     success: function (data) {
-                        if("error" in data){
-                            console.warn("Could not access model API for "+v);
-                        }else{
-                            $.each(data,function(j,w){
-                            
-                                if($.inArray(w.Name,uniqueModels)===-1){
-                                    uniqueModels.push(w.Name);
-                                }
-                            })
+                        if ("error" in data) {
+                            console.warn("Could not access remote model API for " + v);
+                        } else {
+                            processModelsData(data);
                         }
                     }
                 })
-            )     
+            );
         });
-    }else{
+    } else {
         uniqueSystemModelRequests.push(
             $.ajax({
                 type: "GET",
-                url: 'api/models',
+                url: 'api/overlays/models',
+                cache: false,
                 dataType: 'json',
                 success: function (data) {
-                    $.each(data,function(j,w){
-                    
-                        if($.inArray(w.Name,uniqueModels)===-1){
-                            uniqueModels.push(w.Name);
-                        }
-                    })
+                    processModelsData(data);
+                },
+                error: function (jqXHR, textStatus, errorThrown) {
+                    console.error("Model fetch failed:", textStatus, errorThrown);
                 }
             })
-        )        
+        );
     }
-
-    
     return uniqueSystemModelRequests;
 }
 
-function renderModelSelections(){
-    $('.fpp-WledEffects-Model-Selections label, .fpp-WledEffects-Model-Selections .spinner').remove();
-    $.each(uniqueModels,function(i,v){
-        var isChecked = wledEffectsConfig.models.indexOf(v)>-1 ? 'checked':'';
-        $('.fpp-WledEffects-Model-Selections').append(
-            $('<label>'+v+'</label>').addClass(isChecked?"selected":"").prepend(
-                $('<input type="checkbox" '+isChecked+'/>').data('model-name',v).on('change',function(){
-                    if($(this).is(':checked')){
-                        $(this).parent().addClass('selected');
-                    }else{
-                        $(this).parent().removeClass('selected');
-                    }
+function processModelsData(data) {
+    let modelsArray = Array.isArray(data) ? data : (data.models || data.overlays || data || []);
+    $.each(modelsArray, function(j, w) {
+        let name = w.Name || w.name || w.ModelName || '';
+        if (name && uniqueModels.indexOf(name) === -1) {
+            uniqueModels.push(name);
+        }
+    });
+    uniqueModels.sort();
+}
 
-                    handleModelChecked();
-                    SaveWledEffectsConfig();
-                })
-            )
+function renderModelSelections() {
+    $('.fpp-WledEffects-Model-Selections .spinner, .fpp-WledEffects-Model-Selections p.error, .fpp-WledEffects-Model-Selections label').remove();
+
+    if (uniqueModels.length === 0) {
+        $('.fpp-WledEffects-Model-Selections').append('<p class="error" style="color:red;">No models found</p>');
+        return;
+    }
+
+    wledEffectsConfig.models = Array.isArray(wledEffectsConfig.models) ? wledEffectsConfig.models : [];
+
+    $.each(uniqueModels, function(i, v) {
+        var isChecked = wledEffectsConfig.models.indexOf(v) > -1 ? 'checked' : '';
+        var $label = $('<label>' + v + '</label>').addClass(isChecked ? "selected" : "").prepend(
+            $('<input type="checkbox" ' + isChecked + '/>').data('model-name', v).on('change', function() {
+                if ($(this).is(':checked')) {
+                    $(this).parent().addClass('selected');
+                } else {
+                    $(this).parent().removeClass('selected');
+                }
+                handleModelChecked();
+                SaveWledEffectsConfig();
+            })
         );
+
+        $('.fpp-WledEffects-Model-Selections').append($label);
     });
 }
+
 function applyWLEDConfigToSystems(systems) {
-    $.when.apply(undefined, getUniqueModels()).then(()=>{                  
-        renderModelSelections(uniqueModels)
-        $.each(systems,function(i,v){
-            var isChecked = wledEffectsConfig.systems.indexOf(v.address)>-1 ? 'checked':'';
+    $.when.apply(undefined, getUniqueModels()).then(() => {
+        renderModelSelections();
+        $.each(systems, function(i, v) {
+            var isChecked = wledEffectsConfig.systems.indexOf(v.address) > -1 ? 'checked' : '';
             $('#fpp-WledEffects-systems').append(
-                $('<label>'+v.hostname+' ('+v.address+')</label>').addClass(isChecked?"selected":"").prepend(
-                    $('<input type="checkbox" '+isChecked+'/>').data('address',v.address).on('change',function(){
-                        if($(this).is(':checked')){
+                $('<label>' + v.hostname + ' (' + v.address + ')</label>').addClass(isChecked ? "selected" : "").prepend(
+                    $('<input type="checkbox" ' + isChecked + '/>').data('address', v.address).on('change', function() {
+                        if ($(this).is(':checked')) {
                             $(this).parent().addClass('selected');
-                        }else{
+                        } else {
                             $(this).parent().removeClass('selected');
                         }
-  
                         handleSystemChecked();
-                        $.when.apply(undefined, getUniqueModels()).then(()=>{                  
-                            renderModelSelections(uniqueModels);
+                        $.when.apply(undefined, getUniqueModels()).then(() => {
+                            renderModelSelections();
                             SaveWledEffectsConfig();
-                        });  
+                        });
                     })
                 )
             );
-    
         });
         handleModelChecked();
         handleSystemChecked();
-        $('#fpp-WledEffects-MultisyncEnabled').prop('checked',wledEffectsConfig.multisync).on('change',function(){
+        $('#fpp-WledEffects-MultisyncEnabled').prop('checked', wledEffectsConfig.multisync).on('change', function() {
             wledEffectsConfig.multisync = $(this).is(':checked');
+
+            // Immediately update systems
             handleMultisyncChecked();
-            $.when.apply(undefined, getUniqueModels()).then(()=>{                  
-                renderModelSelections(uniqueModels);
+
+            // Clear old models to force refresh
+            uniqueModels = [];
+
+            // Re-fetch and render with error handling
+            $.when.apply(undefined, getUniqueModels()).then(() => {
+                renderModelSelections();
                 SaveWledEffectsConfig();
-            });  
-            
-        })
-            
+            }).fail(function() {
+                console.error("Multisync model fetch failed after toggle");
+                $('.fpp-WledEffects-Model-Selections').append('<p style="color:red;">Failed to load models from selected systems</p>');
+            });
+        });
     });
-    
-    $('#fpp-WledEffects-Colors button').each(function(i,v){
-        var wledColorId = $(this).data('wled-color-id');
-        $(this).colpick({
-            colorScheme:'flat',
-            layout:'rgbhex',
-            color:wledEffectsConfig.colors[i],
-            onSubmit:function(hsb,newHex,rgb,el) {
-                setWledColor(wledColorId,newHex);
-            }
-        }).css({backgroundColor:wledEffectsConfig.colors[i]});
-    });
-    $('#fpp-WledEffects-brightness').val(wledEffectsConfig.brightness).on('change',function(){
-        wledEffectsConfig.brightness=$(this).val();
-        SaveWledEffectsConfig();
-    });
-    $('#fpp-WledEffects-speed').val(wledEffectsConfig.speed).on('change',function(){
-        wledEffectsConfig.speed=$(this).val();
-        SaveWledEffectsConfig();
-    });
-    $('#fpp-WledEffects-intensity').val(wledEffectsConfig.intensity).on('change',function(){
-        wledEffectsConfig.intensity=$(this).val();
-        SaveWledEffectsConfig();
-    });
+
+    if ($('#fpp-WledEffects-Colors button').length) {
+        $('#fpp-WledEffects-Colors button').each(function(i) {
+            var wledColorId = $(this).data('wled-color-id');
+            $(this).colpick({
+                colorScheme: 'flat',
+                layout: 'rgbhex',
+                color: wledEffectsConfig.colors[i] || '#ff0000',
+                onSubmit: function(hsb, newHex) {
+                    setWledColor(wledColorId, newHex);
+                }
+            }).css({backgroundColor: wledEffectsConfig.colors[i] || '#ff0000'});
+        });
+    }
 }
 
-$(function(){
-    $.get('api/overlays/effects').done(function(data) {
-        $.each(data, function(i,v) {
-            var effectButton=$('<button>' + v + '</button>').click(function() {
-                setWledEffect({
-                    effect:v
-                });
-            });
-            $('#availableWledEffects').append($('<div class="col-lg-4 col-md-66" />').append(effectButton));
-        });
-    });
-    $.ajax({
-        type: "GET",
-        url: 'api/fppd/multiSyncSystems',
-        dataType: 'json',
-        success: function (data) {
-            uniqueSystems={}
-            var systems = data.systems;
-            $.each(systems,function(i,v){
-                if(v.uuid!=""){
-                    uniqueSystems[v.uuid]=v;
-                }else{
-                    uniqueSystems[i]=v;
-                }          
-            })
-            uniqueSystemIps=getUniqueSystemIps(uniqueSystems);
-            
-            $.ajax({
-                type: "GET",
-                url: 'api/configfile/plugin.fpp-WledEffects.json',
-                error: function(json) {
-                    wledEffectsConfig = {
-                        colors:[
-                            '#ff0000',
-                            '#00ff00',
-                            '#0000ff'
-                        ],
-                        brightness:128,
-                        speed:128,
-                        intensity:128,
-                        bufferMapping:'Horizontal',
-                        palette:'Default',
-                        multisync:true,
-                        models:[],
-                        systems:uniqueSystemIps
-                    }
-                    applyWLEDConfigToSystems(systems);
-                },
-                success: function (json) {                 
-                    wledEffectsConfig = json;
-                    applyWLEDConfigToSystems(systems);
-                }
-            });
-
-        }
-    })
-
-        
-  
-    $('#fpp-WledEffects-reset').on('click',function(){
-        $.ajax({
-            url: "plugin.php?plugin=fpp-WledEffects&page=resetpluginsettings.php",
-        }).done(function() {
-            $.jGrowl("fpp-WledEffects Plugin Settings have been reset",{themeState:'success'});
-        });
-    })
-    $('#cancelEffects').on('click',function(){
-        stopWledEffects();
-    });
-    $('.fpp-WledEffects-Model-Grouping-Heading input[type=checkbox]').on('change',function(){
-        $(this).parent().parent().next().find('input[type=checkbox]').prop('checked', $(this).is(':checked'));
-        if($(this).is(':checked')){
-            $(this).parent().parent().next().find('input[type=checkbox]').parent().addClass("selected")
-        }else{
-            $(this).parent().parent().next().find('input[type=checkbox]').parent().removeClass("selected")
-        }
-        wledEffectsConfig.models = getSelectedModels();
-        SaveWledEffectsConfig();
-    });
-    
-    $('.fpp-WledEffects-Model-Toggle').click(function(){
-        $(this).parent().toggleClass('open')
-    })
-
-})
-function handleModelChecked(){
+function handleModelChecked() {
     var allChecked = true;
-    $('.fpp-WledEffects-Model-Selections input[type=checkbox]').each(function(){
-        if(!$(this).is(':checked')){
-            allChecked=false
-        }
-    })
+    $('.fpp-WledEffects-Model-Selections input[type=checkbox]').each(function() {
+        if (!$(this).is(':checked')) allChecked = false;
+    });
     $('.fpp-WledEffects-Model-Grouping-Heading input[type=checkbox]').prop('checked', allChecked);
     wledEffectsConfig.models = getSelectedModels();
-    
 }
-function handleSystemChecked(){
+
+function handleSystemChecked() {
     wledEffectsConfig.systems = getSelectedSystems();
-    
 }
-function handleMultisyncChecked(){
-    $('#fpp-WledEffects-systems input[type=checkbox]').each(function(){
-        if(uniqueSystemIps.indexOf($(this).data('address'))>-1){          
-            $(this).prop('checked', $('#fpp-WledEffects-MultisyncEnabled').is(':checked'));
-            if($('#fpp-WledEffects-MultisyncEnabled').is(':checked')){
-                $(this).parent().addClass('selected');
-            }else{
-                $(this).parent().removeClass('selected');
-            }
+
+function handleMultisyncChecked() {
+    wledEffectsConfig.systems = [];
+    $('#fpp-WledEffects-systems input[type=checkbox]').each(function() {
+        if ($(this).is(':checked')) {
+            var addr = $(this).data('address');
+            if (addr) wledEffectsConfig.systems.push(addr);
+            $(this).parent().addClass('selected');
+        } else {
+            $(this).parent().removeClass('selected');
         }
     });
-    handleSystemChecked();
+}
 
+function setWledColor(wledColorId, newHex) {
+    $('[data-wled-color-id=' + wledColorId + ']').css({backgroundColor: '#' + newHex}).data('color', '#' + newHex).colpickHide();
+    wledEffectsConfig.colors[wledColorId - 1] = '#' + newHex;
+    SaveWledEffectsConfig();
 }
-function setWledColor(wledColorId,newHex){
-        $('[data-wled-color-id='+wledColorId+']').css({backgroundColor:'#'+newHex}).data('color','#'+newHex).colpickHide();
-        wledEffectsConfig["colors"][wledColorId-1]='#'+newHex;
-        SaveWledEffectsConfig();
-}
-function stopWledEffects(options){
+
+function stopWledEffects() {
     $.ajax({
         type: "POST",
         url: 'api/command',
         dataType: 'json',
         data: JSON.stringify({
-            "command":"Overlay Model Effect",
-            "multisyncCommand":wledEffectsConfig.multisync,
-            "multisyncHosts":wledEffectsConfig.systems.join(','),
-            "args": [
-                wledEffectsConfig.models.join(','),
-                "Enabled",
-                "Stop Effects"
-            ]
+            "command": "Overlay Model Effect",
+            "multisyncCommand": wledEffectsConfig.multisync,
+            "multisyncHosts": wledEffectsConfig.systems.join(','),
+            "args": [wledEffectsConfig.models.join(','), "Enabled", "Stop Effects"]
         }),
-        contentType: 'application/json',
-        success: function (data) {
-        }
+        contentType: 'application/json'
     });
 }
-function setWledEffect(options){
-    $.get("api/overlays/effects/"+options.effect).done(function(data) {
+
+function setWledEffect(options) {
+    $.get("api/overlays/effects/" + options.effect).done(function(data) {
         $("#EffectName").html(options.effect);
         for (var x = 1; x < 25; x++) {
             $('#wledTblCommandEditor_arg_' + x + '_row').remove();
@@ -330,19 +245,13 @@ function CreateEffectJSON() {
     json["args"].push($("#EffectName").html());
     for (var x = 1; x < 20; x++) {
         var inp = $("#wledTblCommandEditor_arg_" + x);
-        var val = inp.val();
-        if (inp.attr('type') == 'checkbox') {
-            if (inp.is(":checked")) {
-                json["args"].push("true");
+        if (inp.length) {
+            var val = inp.val();
+            if (inp.attr('type') === 'checkbox') {
+                json["args"].push(inp.is(":checked") ? "true" : "false");
             } else {
-                json["args"].push("false");
+                json["args"].push(val);
             }
-        } else if (inp.attr('type') == 'number' || inp.attr('type') == 'text') {
-            json["args"].push(val);
-        } else if (Array.isArray(val)) {
-            json["args"].push(val.toString());
-        } else if (typeof val != "undefined") {
-            json["args"].push(val);
         }
     }
     return json;
@@ -355,10 +264,89 @@ function RunWledEffect() {
         url: 'api/command',
         dataType: 'json',
         data: JSON.stringify(json),
-        contentType: 'application/json',
-        success: function (data) {
-        }
+        contentType: 'application/json'
     });
 }
 
+$(document).ready(function() {
+    $.get('api/overlays/effects').done(function(data) {
+        $.each(data, function(i, v) {
+            var btn = $('<button>' + v + '</button>').click(function() {
+                setWledEffect({effect: v});
+                $('html, body').animate({
+                    scrollTop: $('#fpp-WledEffects-controls-tab').offset().top - 100
+                }, 500);
+            });
+            $('#availableWledEffects').append($('<div class="col-lg-4 col-md-66" />').append(btn));
+        });
+    });
 
+    $.ajax({
+        type: "GET",
+        url: 'api/fppd/multiSyncSystems',
+        dataType: 'json',
+        success: function (data) {
+            var systems = data.systems || [];
+            var uniqueSystems = {};
+            $.each(systems, function(i, v) {
+                uniqueSystems[v.uuid || i] = v;
+            });
+            uniqueSystemIps = getUniqueSystemIps(uniqueSystems);
+
+            $.ajax({
+                type: "GET",
+                url: 'api/configfile/plugin.fpp-WledEffects.json',
+                cache: false,
+                error: function() {
+                    wledEffectsConfig = {
+                        colors: ['#ff0000', '#00ff00', '#0000ff'],
+                        brightness: 128,
+                        speed: 128,
+                        intensity: 128,
+                        bufferMapping: 'Horizontal',
+                        palette: 'Default',
+                        multisync: false,
+                        models: [],
+                        systems: uniqueSystemIps
+                    };
+                    applyWLEDConfigToSystems(systems);
+                },
+                success: function (json) {
+                    wledEffectsConfig = json || wledEffectsConfig;
+                    applyWLEDConfigToSystems(systems);
+                }
+            });
+        }
+    });
+
+    $('#fpp-WledEffects-reset').on('click', function() {
+        $.ajax({ url: "plugin.php?plugin=fpp-WledEffects&page=resetpluginsettings.php" }).done(function() {
+            $.jGrowl("Plugin settings reset", {themeState: 'success'});
+            location.reload();
+        });
+    });
+
+    $('#cancelEffects').on('click', stopWledEffects);
+
+    $('.fpp-WledEffects-Model-Grouping-Heading input[type=checkbox]').on('change', function() {
+        var checked = $(this).is(':checked');
+        $(this).parent().parent().next().find('input[type=checkbox]').prop('checked', checked);
+        $(this).parent().parent().next().find('label').toggleClass('selected', checked);
+        wledEffectsConfig.models = getSelectedModels();
+        SaveWledEffectsConfig();
+    });
+
+    $('.fpp-WledEffects-Model-Toggle').on('click', function() {
+        $(this).parent().toggleClass('open');
+        $(this).find('i').toggleClass('fa-chevron-down fa-chevron-up');
+    });
+
+    setTimeout(() => {
+        $.when.apply(undefined, getUniqueModels()).then(() => {
+            renderModelSelections();
+            if (uniqueModels.length === 0) {
+                setTimeout(() => $.when.apply(undefined, getUniqueModels()).then(renderModelSelections), 1500);
+            }
+        });
+    }, 500);
+});


### PR DESCRIPTION
Not sure what the current go to for wled plugin is, but i found this on first, its up to date , might need more testing but so far does what i would expect it to.

- Use /api/overlays/models endpoint instead of deprecated /api/models
- Prevent duplicate model rendering by clearing old labels
- Add defensive handling for undefined models array
- Improve multisync toggle to reliably refresh model list
- Implement missing down arrow toggle for model list
- Add auto-scroll to controls after selecting an effect

Tested on FPP 9.4 should remain backward-compatible with 7.x/8.x. 